### PR TITLE
last taged version is behind the most recent version of swipe

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,6 +21,6 @@
     "tests"
   ],
   "dependencies": {
-    "swipe": "~2.0.0"
+    "swipe": "86c96eaa3c6177f04330bb606f50049d39079b8e"
   }
 }


### PR DESCRIPTION
version 2.0.0. doesn't have the ability to swipe to the last slide when swiping to the right (navigating to the left) on the first slide and vice versa
